### PR TITLE
エラーメッセージの日本語表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,5 @@ gem "aws-sdk-s3", require: false
 group :production do
   gem 'unicorn', '5.4.1'
 end
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -359,6 +362,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,7 +18,7 @@ class Item < ApplicationRecord
     validates :price
   end
 
-  with_options numericality: { other_than: 1 } do
+  with_options numericality: { other_than: 1, message: "を入力してください" } do
     validates :category_id
     validates :condition_id
     validates :delivery_fee_id

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -3,16 +3,16 @@ class ItemOrder
   attr_accessor :postal_code, :prefecture_id, :area, :address, :building, :phone, :item_id, :user_id, :token
 
   with_options presence: true do
-    validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/, message: 'is invalid. Include hyphen(-)' }
+    validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/, message: 'はハイフンを含めてください' }
     validates :area
     validates :address
-    validates :phone, format: { with: /\A[0-9]{1,11}\z/, message: 'gotta be within 11 numbers' }
+    validates :phone, format: { with: /\A[0-9]{1,11}\z/, message: 'は11桁以内の数字を入力してください' }
     validates :token
     validates :user_id
     validates :item_id
   end
 
-  validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :prefecture_id, numericality: { other_than: 1, message: "を入力してください" }
 
   def save
     order = Order.create(user_id: user_id, item_id: item_id)

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module Furima33934
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメールの変更（%{email}）をお知らせいたします。
+        message_unconfirmed: 
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,4 +18,12 @@ ja:
        delivery_fee_id: 配送料の負担
        prefecture_id: 発送元の地域
        days_taken_id: 発送までの日数
-       
+ activemodel:
+   attributes:
+     item_order:
+       postal_code: 郵便番号
+       area: 市区町村
+       address: 番地
+       phone: 電話番号
+       token: クレジットカード情報
+       prefecture_id: 都道府県

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,21 @@
+ja:
+ activerecord:
+   attributes:
+     user:
+       nickname: ニックネーム
+       last_name_kanji: 名字(全角)
+       first_name_kanji: 名前(全角)
+       last_name_kana: 名字(カタカナ)
+       first_name_kana: 名字(カタカナ)
+       date_of_birth: 生年月日
+     item:
+       name: 商品名
+       images: 画像
+       description: 商品説明
+       price: 価格
+       category_id: カテゴリ
+       condition_id: 商品状態
+       delivery_fee_id: 配送料の負担
+       prefecture_id: 発送元の地域
+       days_taken_id: 発送までの日数
+       

--- a/spec/models/item_order_spec.rb
+++ b/spec/models/item_order_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe ItemOrder, type: :model do
       it 'postal_codeにハイフンが含まれていない場合' do
         @item_order.postal_code = '1234567'
         @item_order.valid?
-        expect(@item_order.errors.full_messages).to include('Postal code is invalid. Include hyphen(-)')
+        expect(@item_order.errors.full_messages).to include("Postal code はハイフンを含めてください")
       end
 
       it 'prefecture_idが1の場合' do
         @item_order.prefecture_id = 1
         @item_order.valid?
-        expect(@item_order.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@item_order.errors.full_messages).to include("Prefecture を入力してください")
       end
 
       it 'areaが空の場合' do
@@ -55,19 +55,19 @@ RSpec.describe ItemOrder, type: :model do
       it 'phoneが12桁以上の場合' do
         @item_order.phone = '123456789123'
         @item_order.valid?
-        expect(@item_order.errors.full_messages).to include('Phone gotta be within 11 numbers')
+        expect(@item_order.errors.full_messages).to include("Phone は11桁以内の数字を入力してください")
       end
 
       it 'phoneが全角文字の場合' do
         @item_order.phone = 'アイウエオ'
         @item_order.valid?
-        expect(@item_order.errors.full_messages).to include('Phone gotta be within 11 numbers')
+        expect(@item_order.errors.full_messages).to include('Phone は11桁以内の数字を入力してください')
       end
 
       it 'phoneが英数混在の場合' do
         @item_order.phone = '123abc456'
         @item_order.valid?
-        expect(@item_order.errors.full_messages).to include('Phone gotta be within 11 numbers')
+        expect(@item_order.errors.full_messages).to include('Phone は11桁以内の数字を入力してください')
       end
 
       it 'tokenが空の場合' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -52,31 +52,31 @@ RSpec.describe Item, type: :model do
       it 'category_idが1の場合' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category must be other than 1')
+        expect(@item.errors.full_messages).to include('Category を入力してください')
       end
 
       it 'condition_idが1の場合' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Condition must be other than 1')
+        expect(@item.errors.full_messages).to include('Condition を入力してください')
       end
 
       it 'delivery_fee_idが1の場合' do
         @item.delivery_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Delivery fee must be other than 1')
+        expect(@item.errors.full_messages).to include('Delivery fee を入力してください')
       end
 
       it 'prefecture_idが1の場合' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
+        expect(@item.errors.full_messages).to include('Prefecture を入力してください')
       end
 
       it 'days_taken_idが1の場合' do
         @item.days_taken_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Days taken must be other than 1')
+        expect(@item.errors.full_messages).to include('Days taken を入力してください')
       end
 
       it 'priceが空の場合' do


### PR DESCRIPTION
# WHAT
ログイン、新規登録、出品、購入時に出力されるエラーの日本語化。

# WHY
日本人のユーザーがどのようなエラーが表示されたかを素早く理解できるようにするため。